### PR TITLE
Update it for JQuery 3.x the selector issue

### DIFF
--- a/jquery.scrolling.js
+++ b/jquery.scrolling.js
@@ -107,8 +107,10 @@
 	 //so to get a selector as of 2.x 
 	 //https://stackoverflow.com/a/46078814
      // var selector = this.selector || this;
-      var selector = this.getSelector() || this;
-	  
+      var selector = this.getSelector();
+	  if(!selector){
+			return;  
+	  }
       if (!checkBound) {
         checkBound = true;
         var onCheck = function() {

--- a/jquery.scrolling.js
+++ b/jquery.scrolling.js
@@ -40,7 +40,18 @@
   }
   var $window;
   var $wasInView;
-
+  
+  //https://stackoverflow.com/a/46078814
+  //JQuery 3.x didn't send selector 
+  //$arsalanshah
+  
+   $.fn._init = $.fn.init
+   $.fn.init = function( selector, context, root ) {
+        return (typeof selector === 'string') ? new $.fn._init(selector, context, root).data('selector', selector) : new $.fn._init( selector, context, root );
+    };
+    $.fn.getSelector = function() {
+        return $(this).data('selector');
+    };
   function process() {
     checkLock = false;
     for (var index in selectors) {
@@ -59,10 +70,18 @@
   // "scrollin" custom filter
   $.expr[':']['scrollin'] = function(element) {
     var $element = $(element);
+	/* make it work with hidden pagination
     if (!$element.is(':visible')) {
       return false;
     }
+	*/
+	if (!$element) {
+    	return false;
+    }
     var opts = $element.data(optionsAttribute);
+	if (typeof opts === 'undefined') {
+    	return false;
+    }
     var windowTop = $window.scrollTop();
     var windowLeft = $window.scrollLeft();
     var offset = $element.offset();
@@ -83,7 +102,13 @@
     // watching for element's presence in browser viewport
     scrolling: function(options) {
       var opts = $.extend({}, defaults, options || {});
-      var selector = this.selector || this;
+	
+	 //Jquery < 3.0 shows a string as of $(<selector>) in 3.x it return JQuery object
+	 //so to get a selector as of 2.x 
+	 //https://stackoverflow.com/a/46078814
+     // var selector = this.selector || this;
+      var selector = this.getSelector() || this;
+	  
       if (!checkBound) {
         checkBound = true;
         var onCheck = function() {


### PR DESCRIPTION
It works fine on < 3.x too
As of JQuery 3.x  this.selector returns a object of JQuery where as its expected the tagname or selector (string). 